### PR TITLE
Add Deserialize trait to AppLabel

### DIFF
--- a/src/app_label.rs
+++ b/src/app_label.rs
@@ -1,9 +1,10 @@
+use serde::Deserialize;
 use serde::Serialize;
 
 use crate::sifis_api::ApiLabel;
 
 /// Sifis application information.
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct AppLabel {
     /// Application name
     pub app_name: String,


### PR DESCRIPTION
Need the App Label to be deserializable, in order to use it in `sifis-xacml` repository.